### PR TITLE
Contracts type narrowing

### DIFF
--- a/src/Modular.Abstractions/Contracts/Contract.cs
+++ b/src/Modular.Abstractions/Contracts/Contract.cs
@@ -3,10 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Runtime.Serialization;
+using Modular.Abstractions.Messaging;
 
 namespace Modular.Abstractions.Contracts;
 
-public abstract class Contract<T> : IContract where T : class
+public abstract class Contract<T> : IContract where T : class, IMessage
 {
     private readonly ISet<string> _required = new HashSet<string>();
     public Type Type { get; } = typeof(T);

--- a/src/Modular.Infrastructure/Contracts/ContractRegistry.cs
+++ b/src/Modular.Infrastructure/Contracts/ContractRegistry.cs
@@ -78,7 +78,7 @@ public class ContractRegistry : IContractRegistry
                 throw new ContractException($"Request registration was not found for path: '{path}'.");
             }
 
-            _logger.LogTrace($"Validating the contracts for path: '{path}'...");
+            _logger.LogTrace("Validating the contracts for path: {Path}", path);
             if (requestType != typeof(Empty))
             {
                 ValidateContract(requestType, path);
@@ -89,7 +89,7 @@ public class ContractRegistry : IContractRegistry
                 ValidateContract(responseType, path);
             }
 
-            _logger.LogTrace($"Validated the contracts for path: '{path}'.");
+            _logger.LogTrace("Validated the contracts for path: {Path}", path);
         }
     }
 
@@ -129,8 +129,11 @@ public class ContractRegistry : IContractRegistry
             throw new ContractException($"Contract: '{contractName}' was not found in module: '{module}'.");
         }
 
-        _logger.LogTrace($"Validating the contract for: '{contractName}', " +
-                         $"from module: '{contractModule}', original module: '{module}'...");
+        _logger.LogTrace(
+            "Validating the contract for: '{ContractName}', from module: '{ContractModule}', original module: '{Module}'",
+            contractName,
+            contractModule,
+            module);
 
         var originalContract = FormatterServices.GetUninitializedObject(originalType);
         var originalContractType = originalContract.GetType();
@@ -144,8 +147,11 @@ public class ContractRegistry : IContractRegistry
                 contractModule, path);
         }
 
-        _logger.LogTrace($"Successfully validated the contract for: '{contractName}', " +
-                         $"from module: '{contractModule}', original module: '{module}'.");
+        _logger.LogTrace(
+            "Successfully validated the contract for: '{ContractName}', from module: '{ContractModule}', original module: '{Module}'",
+            contractName,
+            contractModule,
+            module);
     }
 
     private static void ValidateProperty(PropertyInfo localProperty, PropertyInfo originalProperty,

--- a/src/Modular.Infrastructure/Contracts/ContractRegistry.cs
+++ b/src/Modular.Infrastructure/Contracts/ContractRegistry.cs
@@ -24,7 +24,7 @@ public class ContractRegistry : IContractRegistry
         _logger = logger;
     }
 
-    public IContractRegistry Register<T>() where T : class
+    public IContractRegistry Register<T>() where T : class, IContract
     {
         var contract = GetContractType<T>();
         _contracts.Add(contract);

--- a/src/Modular.Infrastructure/Contracts/ContractRegistry.cs
+++ b/src/Modular.Infrastructure/Contracts/ContractRegistry.cs
@@ -217,7 +217,7 @@ public class ContractRegistry : IContractRegistry
         }
     }
         
-    private class Empty
+    private class Empty : IMessage
     {
     }
         

--- a/src/Modular.Infrastructure/Contracts/IContractRegistry.cs
+++ b/src/Modular.Infrastructure/Contracts/IContractRegistry.cs
@@ -1,11 +1,12 @@
 using System.Collections.Generic;
 using System.Reflection;
+using Modular.Abstractions.Contracts;
 
 namespace Modular.Infrastructure.Contracts;
 
 public interface IContractRegistry
 {
-    IContractRegistry Register<T>() where T : class;
+    IContractRegistry Register<T>() where T : class, IContract;
 
     IContractRegistry RegisterPath(string path);
 


### PR DESCRIPTION
# Scope
Types narrowing for `IContract` related registration and `Contract<T>`

#Justification

## IContractRegistry
Current constraints allow for __any__ class to act as a type parameter for `.Register<T>()` method. As this would not work I want to improve the developer experience by allowing the compiler to indicate that a given invocation is not supported

## Contract\<T\>
Semantically contracts are intended to validate messages exchanged between modules. Narrowing down the type constraint helps to enforce those sematics.